### PR TITLE
feat: catchment refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,66 @@
+# Getting started
 
-## Getting started
+## PC configuration
 
-### PC configuration Linux
+### Linux
+
 We need node and yarn. On linux a convenient way is to use Node Version Manager (https://github.com/nvm-sh/nvm)
 
-```
+```bash
 nvm install 14.19.2
 nvm use 14.19.2
 ```
-On windows install node in version 14.
 
 Next, install yarn globally:
-```
-npm install -g yarn 
+
+```bash
+npm install -g yarn
 ```
 
-### PC configuration Windows 
-https://nodejs.org/download/release/v14.19.2/node-v14.19.2-x64.msi
+### Windows
+
+On windows install node in version 14, which you can download [here](https://nodejs.org/download/release/v14.19.2/node-v14.19.2-x64.msi).
 
 Please tick to install all additional tools with "chocolatey" that should cover all of the other requirements (visual studio, python etc.)
 
+## Running the web-app locally
 
-### Running the web-app
-
+### Linux and Windows
 
 Install packages using yarn and then start the app:
 
-```sh
-yarn
+```bash
+yarn install
 
-yarn start
-```
-In order to reset the database before the next build you need to remove the bahis files. On linux run:
-```
-rm -rf ~/.config/bahis  
+yarn react-start
 ```
 
-### build setup file
+In a second terminal, start electron with:
 
-for windows
-```sh
-yarn win-build
+```bash
+yarn electron .
 ```
 
-for linux
-```sh
+In order to reset the database before the next build you need to remove the bahis files, e.g. on linux:
+
+```bash
+rm -rf ~/.config/bahis
+```
+
+Changes made should auto-render.
+
+## Building the app for distribution
+
+### For Linux
+
+```bash
 yarn linux-build
+```
+
+### For Windows
+
+```bash
+yarn win-build
 ```
 
 ## Re-run of the app in dev mode
@@ -54,11 +69,14 @@ yarn linux-build
 rm -rf  ~/.config/bahis && export BAHIS_SERVER="http://www.bahis2-dev.net" && yarn start
 ```
 
-There is some leak in UI code that might give an error saying that there are too many watchers. Try this 
+There is some leak in UI code that might give an error saying that there are too many watchers. Try this
+
 ```
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
+
 (https://stackoverflow.com/questions/55763428/react-native-error-enospc-system-limit-for-number-of-file-watchers-reached)
+
 ## Configuration
 
 The configurations are located in the `configs` directory and are split into two modules:

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "electron-updater": "^4.0.4"
   },
   "build": {
+    "extends": null,
     "appId": "com.electron.bahis",
     "publish": [
       {

--- a/public/modules/syncFunctions.js
+++ b/public/modules/syncFunctions.js
@@ -24,7 +24,8 @@ CREATE TABLE data( data_id INTEGER PRIMARY KEY, submitted_by TEXT NOT NULL, subm
 CREATE TABLE app_log( time TEXT);
 CREATE TABLE module_image( id INTEGER PRIMARY KEY AUTOINCREMENT, module_id TEXT NOT NULL, image_name TEXT NOT NULL, directory_name TEXT );
 CREATE TABLE form_choices( id INTEGER PRIMARY KEY AUTOINCREMENT, value_text TEXT, xform_id TEXT , value_label TEXT, field_name TEXT, field_type TEXT);
-CREATE TABLE geo( geo_id INTEGER PRIMARY KEY AUTOINCREMENT, div_id TEXT NOT NULL, division TEXT NOT NULL, dis_id TEXT NOT NULL, district TEXT NOT NULL, upz_id TEXT NOT NULL, upazila TEXT NOT NULL);`;
+CREATE TABLE geo( geo_id INTEGER PRIMARY KEY AUTOINCREMENT, div_id TEXT NOT NULL, division TEXT NOT NULL, dis_id TEXT NOT NULL, district TEXT NOT NULL, upz_id TEXT NOT NULL, upazila TEXT NOT NULL);
+CREATE TABLE geo_cluster( id INTEGER PRIMARY KEY AUTOINCREMENT, value INTEGER NOT NULL, name TEXT NOT NULL, loc_type INTEGER NOT NULL , parent INTEGER NOT NULL);`;
 
 
 /** fetches data from server to app


### PR DESCRIPTION
## Description

In an attempt to solve the login / sync timeouts, I have removed the catchment sync that occurs during these actions. As the catchments should change regularly I think this is fine. Right now it will only sync when a user logs in for the first time (either as part of `signIn`, where new users are treated differently, or changeUser, which is called by the front-end when the change of user message appears).

What would be nice is to have this also synchronise (or be flagged to) as part of `autoUpdateBahis` (#25).

closes #21 
relates road86/bahis-serve#1

## Testing

As we are still on manual tests I have:

- [x] deleted `~/.config/devbahis` and run a clean app
- [x] logged in as a user
- [x] successfully submitted data
- [x] synchronised local data
- [x] closed the app and logged back in as that same user
- [x] closed the app and logged in as a different user and done the same things

The only thing I noticed is that a new user db doesn't include certain datas used for prepopulating forms; however, that is solved by a sync (#26).

Running the catchment synchronisation is still slow - but I think I can speed that up too in bahis-serve (road86/bahis-serve#8).

## Database Changes

We now manually create the table geo_cluster when we initialise a database. I am not sure how this was being created before but it happens during app sync _after_ successful login, whereas we now do catchments _during_ login.

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [x] New database changes have been committed.
