### PR TITLE
fix: make csvDataSync definition consistent with original use

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -1059,7 +1059,7 @@ const startAppSync = (event, name, time) => {
     })
     .then(() => {
         // sync the csv Data ?
-        csvDataSync(name);
+        csvDataSync(db, name);
     })
     .catch((err) => {
       electronLog.info(`----------------- || App Sync Failed At Login || ----------------------------\n`, err);
@@ -1083,7 +1083,7 @@ const requestDataSync = async (event, username) => {
  * @param {IpcMainEvent} event - the default ipc main event
  * @returns {string} - success when completes; otherwise, failed if error occurs
  */
-const csvDataSync = async (username) => {
+const csvDataSync = async (db, username) => {
   electronLog.info("XIM1 csvDataSync")
   try {
     const tableExistStmt = 'SELECT name FROM sqlite_master WHERE type=? AND name=?';


### PR DESCRIPTION
## Description

There was some inconsistency between the definition of `csvDataSync(name)` and one out of the two calls (`csvDataSync(db, name)`). This actually meant that datasync only happened on a sign in sync and not on a button push sync. I have gone for the more explicit option and made this consistent.

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
