### PR TITLE
feat: make sync blocking timeout

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -162,7 +162,7 @@ function Form(props: formProps) {
       ) : (
         <div style={{ marginTop: '10%' }}>
           <Typography color="secondary" component="h1" variant="h4" align="center">
-            Could not find form definition
+            Form is loading. If form does not render please Sync Now and then press Back and try again.
           </Typography>
         </div>
       )}

--- a/src/components/page/Header/index.tsx
+++ b/src/components/page/Header/index.tsx
@@ -47,6 +47,18 @@ function Header(props: HeaderProps) {
 
   // }, [appConfigSyncComplete]);
 
+  React.useEffect(() => {
+    setTimeout(() => {
+      setWaitingForFormSync(false);
+    }, 45000);
+  }, [isWaitingForFormSync]);
+
+  React.useEffect(() => {
+    setTimeout(() => {
+      setWaitingForDataSync(false);
+    }, 45000);
+  }, [isWaitingForDataSync]);
+
   const handleAppSync = async () => {
     props.setLastSyncTime('Sync in progress');
     setWaitingForFormSync(true);
@@ -104,9 +116,7 @@ function Header(props: HeaderProps) {
       anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       key={'topcenter'}
     >
-      <Alert severity="info">
-        Synchronising data. 
-      </Alert>
+      <Alert severity="info">Synchronising data.</Alert>
     </Snackbar>
   );
 


### PR DESCRIPTION
## Description

The state that prevents users rage clicking the sync button now resets after 45 seconds. This should mean that if the system hangs / crashes / timeouts / etc. the user can semi-rage click the sync.

This has a nice benefits that the electron-level API hanging actually seems to get repushed when the user does this.

closes #53 

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
