### PR TITLE
fix: lock geolocation in forms

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -392,7 +392,7 @@ const fetchQueryData = (event, queryString) => {
 
 const configureFreshDatabase = async (data, userData, mac) => {
   const insertStmt = db.prepare(
-    `INSERT INTO users (username, password, macaddress, lastlogin, name, role, organization, branch, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO users (username, password, macaddress, lastlogin, name, role, organization, branch, email, upazila) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   insertStmt.run(
     data.user_name,
@@ -404,6 +404,7 @@ const configureFreshDatabase = async (data, userData, mac) => {
     data.organization,
     data.branch,
     data.email,
+    data.upazila,
   );
 
   electronLog.log(`Created db with user details, now synchronising form config and catchments for ${data.user_name}`);
@@ -637,9 +638,14 @@ const signIn = async (event, userData) => {
 
 const getErrorMessage = (error) => {
   electronLog.info(error.message);
-  if (error.message.includes("409")) return "Users credentials are not authorized or missing catchment area."
-  else return "Unauthenticated User.";
-}
+  if (error.message.includes('403')) {
+    return 'Only upazilas can use BAHIS-desk, please contact support.';
+  }
+  if (error.message.includes('409')) {
+    return 'Users credentials are not authorized or missing catchment area.';
+  }
+  return 'Unauthenticated User.';
+};
 
 
 const populateCatchment = (catchments) => {

--- a/public/modules/syncFunctions.js
+++ b/public/modules/syncFunctions.js
@@ -15,7 +15,7 @@ const DATA_SYNC_COUNT = `${SERVER_URL}/bhmodule/form/core_admin/data-sync-count/
 const DATA_SYNC_PAGINATED = `${SERVER_URL}/bhmodule/form/core_admin/data-sync-paginated/`;
 const PAGE_LENGTH = 100;
 
-const queries = `CREATE TABLE users( user_id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL, password TEXT NOT NULL, macaddress TEXT, lastlogin TEXT NOT NULL, upazila TEXT , role Text NOT NULL, branch  TEXT NOT NULL, organization  TEXT NOT NULL, name  TEXT NOT NULL, email  TEXT NOT NULL);
+const queries = `CREATE TABLE users( user_id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL, password TEXT NOT NULL, macaddress TEXT, lastlogin TEXT NOT NULL, upazila INTEGER , role Text NOT NULL, branch  TEXT NOT NULL, organization  TEXT NOT NULL, name  TEXT NOT NULL, email  TEXT NOT NULL);
 CREATE TABLE app( app_id INTEGER PRIMARY KEY, app_name TEXT NOT NULL, definition TEXT NOT NULL);
 CREATE TABLE forms( form_id INTEGER PRIMARY KEY, form_name TEXT NOT NULL, definition TEXT NOT NULL, choice_definition TEXT, form_uuid TEXT, table_mapping TEXT, field_names TEXT );
 CREATE TABLE lists( list_id INTEGER PRIMARY KEY, list_name TEXT NOT NULL, list_header TEXT, datasource TEXT, filter_definition TEXT, column_definition TEXT);

--- a/src/components/AppRegister/index.tsx
+++ b/src/components/AppRegister/index.tsx
@@ -170,13 +170,13 @@ function AppRegister(props: any) {
   const [isSignInButtonDisabled, setSignInButtonDisabled] = useState(false);
 
   return (
-    <Grid container={true} spacing={3} direction="row" justify="center" alignItems="center">
+    <Grid container={true} spacing={3} direction="row" justifyContent="center" alignItems="center">
       {isLoadComplete ? (
         <div className={classes.layout}>
           {/* {toastVisible && <Alert color="success">{toastContent.msg}</Alert>} */}
           <Paper className={classes.paper} elevation={3}>
             {toast(toastContent)}
-            <Grid container={true} direction="row" justify="center" alignItems="center">
+            <Grid container={true} direction="row" justifyContent="center" alignItems="center">
               <div className={classes.circle}>
                 <div className={classes.image}>
                   <Avatar variant="square" src="/icon.png" />


### PR DESCRIPTION
## Description

This PR (and one in bahis-serve) are an attempt to solve the geolocation problem described in #60 and elsewhere.

Essentially, there are two fairly big changes:
1. We store the user's upazila ID in the local DB an use this as "truth" for the user's geolocation
2. Whenever a form is loaded we hide the geolocation fields from the user; we then fill this fields based on the user's upazila in the local DB

### TODO / questions

- [x] we have changed how a db is prepared - how will this impact existing users with existing dbs? We don't want users to have to delete their local db so we should catch this - maybe on sync? Or can we do it as part of the update?
- [ ] the bahis-serve change related to this is going to lock users like rupsa out of their accounts - because their account is a district account and not an upazila account. How shall we handle this?
- [x] are existing bahis-desk versions compatible with the bahis-serve changes? if not we can use the version parameter catch

closes #60
requires road86/bahis-serve#14

## Database Changes (delete if not applicable)

Yes, when a new DB is 'prepared' it will now force upazila to be an integer and not text.

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [x] New database changes have been committed.
