### PR TITLE
feat: remove mouzas

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -156,6 +156,9 @@ function Form(props: formProps) {
           if (basicInfoQuestions[question]['name'] === 'upazila') {
             questionsToDelete.push(question);
           }
+          if (basicInfoQuestions[question]['name'] === 'mouza') {
+            questionsToDelete.push(question);
+          }
         }
         questionsToDelete = questionsToDelete.sort((a, b) => b - a);
         console.log(questionsToDelete);


### PR DESCRIPTION
## Description

Part of the issues with the v2.2.x testing includes drop-down options for Mouzas.
As we have permission to remove them entirely, I have done that here.
This makes the other issues a little simpler.

This fix removes them client-side but we should also remove them in the form definitions in bahis-serve but that can wait for v3.

closes #70 

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
